### PR TITLE
Address review comments on #51263 (backport to CMSSW_17_0_X)

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/taus/TauNNIdHW.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/taus/TauNNIdHW.h
@@ -12,24 +12,18 @@
 #include "DataFormats/L1TParticleFlow/interface/layer1_emulator.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
 
-// Input/output precision of the NNPuppiTauModel hls4ml network, matching the
-// model's defines.h (kept here since the weights/layer code now live in the
-// externally-built NNPuppiTauModel package, not in-tree). Named distinctively
-// (not input_t/result_t) to avoid clashing with the generic typedefs other
-// hls4ml model headers define at global scope.
-typedef ap_fixed<16, 10> tauinput_t;
-typedef ap_fixed<16, 6> tauresult_t;
-
 typedef ap_ufixed<16, 14> pt_t;
 typedef ap_fixed<10, 4> etaphi_t;
 
-// Tau NN returns two values
-struct Tau_NN_Result {
-  tauresult_t nn_pt_correction;
-  tauresult_t nn_id;
-};
-
 namespace L1TauEmu {
+  // Input/output precision of the NNPuppiTauModel hls4ml network, matching the
+  // model's defines.h (kept here since the weights/layer code now live in the
+  // externally-built NNPuppiTauModel package, not in-tree). Named distinctively
+  // (not input_t/result_t) and namespaced to avoid clashing with the generic
+  // typedefs other hls4ml model headers define at global scope.
+  typedef ap_fixed<16, 10> tauinput_t;
+  typedef ap_fixed<16, 6> tauresult_t;
+
   // Data types and constants used in the FPGA and FPGA-optimized functions
   //etaphi_base maps physical eta phi units onto bits
   //This way, the least significant bit of etaphi_t is exactly 0.01
@@ -142,14 +136,20 @@ namespace L1TauEmu {
 
 };  // namespace L1TauEmu
 
+// Tau NN returns two values
+struct Tau_NN_Result {
+  L1TauEmu::tauresult_t nn_pt_correction;
+  L1TauEmu::tauresult_t nn_id;
+};
+
 class TauNNIdHW {
 public:
   TauNNIdHW(const std::shared_ptr<hls4mlEmulator::Model> model);
-  ~TauNNIdHW();
+  ~TauNNIdHW() = default;
 
   void initialize(const std::string &iName, int iNParticles);
   void SetNNVectorVar();
-  tauinput_t *NNVectorVar() { return NNvectorVar_.data(); }
+  L1TauEmu::tauinput_t *NNVectorVar() { return NNvectorVar_.data(); }
   Tau_NN_Result EvaluateNN();
   Tau_NN_Result compute(const l1t::PFCandidate &iSeed, std::vector<l1t::PFCandidate> &iParts);
   //void print();
@@ -163,7 +163,7 @@ public:
   //FILE *file_;
 
 private:
-  std::vector<tauinput_t> NNvectorVar_;
+  std::vector<L1TauEmu::tauinput_t> NNvectorVar_;
   std::shared_ptr<hls4mlEmulator::Model> modelRef_;
 };
 

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1NNTauProducer.cc
@@ -219,8 +219,8 @@ void L1NNTauProducer::makeTau_HW(const l1t::PFCandidate& seed,
   input2_t p1y_tot = 0;
   input2_t p1z_tot = 0;
 
-  tauinput_t e1ta_1 = seed.eta();
-  tauinput_t p1hi_1 = seed.phi();
+  L1TauEmu::tauinput_t e1ta_1 = seed.eta();
+  L1TauEmu::tauinput_t p1hi_1 = seed.phi();
   L1TauEmu::pt_t pt = 0;
   L1TauEmu::z0_t z0 = 0;
   L1TauEmu::dxy_t dxy = 0;
@@ -233,10 +233,10 @@ void L1NNTauProducer::makeTau_HW(const l1t::PFCandidate& seed,
         lId++;
         pt = pt + L1TauEmu::pt_t(parts[i0].pt());
 
-        input2_t d1eta = tauinput_t(parts[i0].eta()) - e1ta_1;
-        input2_t d1phi = tauinput_t(parts[i0].phi()) - p1hi_1;
+        input2_t d1eta = L1TauEmu::tauinput_t(parts[i0].eta()) - e1ta_1;
+        input2_t d1phi = L1TauEmu::tauinput_t(parts[i0].phi()) - p1hi_1;
         input2_t d1r2 = d1eta * d1eta + d1phi * d1phi;
-        input2_t tmppt = tauinput_t(parts[i0].pt());
+        input2_t tmppt = L1TauEmu::tauinput_t(parts[i0].pt());
         input2_t half = 0.5;
         p1z_tot = p1z_tot + tmppt * (1 - d1r2 * half);
         p1y_tot = p1y_tot + tmppt * d1phi;
@@ -264,7 +264,7 @@ void L1NNTauProducer::makeTau_HW(const l1t::PFCandidate& seed,
   Tau_NN_Result NN_ouput = fTauNNIdHW_->compute(seed, parts);
 
   // Needed for making PFTau
-  tauinput_t* lNNVector = fTauNNIdHW_->NNVectorVar();
+  L1TauEmu::tauinput_t* lNNVector = fTauNNIdHW_->NNVectorVar();
   float pNNVec[80];
   for (unsigned i0 = 0; i0 < 80; i0++)
     pNNVec[i0] = float(lNNVector[i0]);

--- a/L1Trigger/Phase2L1ParticleFlow/python/L1NNTauProducer_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/L1NNTauProducer_cff.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.Phase2L1ParticleFlow.l1ctLayer1_cff import l1tLayer1Barrel,l1tLayer1HGCal,l1tLayer1
 
+nnPuppiTauModelName = "NNPuppiTauModel_v1"
+
 #from L1Trigger.Phase2L1ParticleFlow.L1NNTauProducer_cfi import *
 
 #L1NNTauProducerPuppi = L1NNTauProducer.clone(
@@ -20,7 +22,7 @@ l1tNNTauProducerPuppi = cms.EDProducer("L1NNTauProducer",
                                       debug           = cms.bool(False),
                                       L1PFObjects     = cms.InputTag('l1tLayer2Deregionizer:Puppi'), #1pfCandidates:Puppi"),#l1pfCandidates
                                       NNFileName      = cms.string("L1Trigger/Phase2L1ParticleFlow/data/tau_3layer_puppi.pb"),
-                                      tauModelPath    = cms.string("NNPuppiTauModel_v1")
+                                      tauModelPath    = cms.string(nnPuppiTauModelName)
 )
 
 l1tNNTauProducerPF = cms.EDProducer("L1NNTauProducer",
@@ -31,6 +33,6 @@ l1tNNTauProducerPF = cms.EDProducer("L1NNTauProducer",
                                       nparticles      = cms.int32(10),
                                       L1PFObjects     = cms.InputTag("l1tLayer1:PF"),#l1pfCandidates
                                       NNFileName      = cms.string("L1Trigger/Phase2L1ParticleFlow/data/tau_3layer.pb"),
-                                      tauModelPath    = cms.string("NNPuppiTauModel_v1")
+                                      tauModelPath    = cms.string(nnPuppiTauModelName)
 )
 

--- a/L1Trigger/Phase2L1ParticleFlow/src/taus/TauNNIdHW.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/src/taus/TauNNIdHW.cc
@@ -4,7 +4,6 @@
 #include "L1Trigger/Phase2L1ParticleFlow/interface/taus/TauNNIdHW.h"
 
 TauNNIdHW::TauNNIdHW(const std::shared_ptr<hls4mlEmulator::Model> model) : modelRef_(model) { NNvectorVar_.clear(); }
-TauNNIdHW::~TauNNIdHW() {}
 
 void TauNNIdHW::initialize(const std::string &iInput, int iNParticles) {
   fNParticles_ = iNParticles;
@@ -19,9 +18,9 @@ void TauNNIdHW::initialize(const std::string &iInput, int iNParticles) {
 void TauNNIdHW::SetNNVectorVar() {
   NNvectorVar_.clear();
   for (unsigned i0 = 0; i0 < fNParticles_; i0++) {
-    tauinput_t pPt = tauinput_t(fPt_.get()[i0]);
-    tauinput_t pEta = tauinput_t(fEta_.get()[i0]);
-    tauinput_t pPhi = tauinput_t(fPhi_.get()[i0]);
+    L1TauEmu::tauinput_t pPt = L1TauEmu::tauinput_t(fPt_.get()[i0]);
+    L1TauEmu::tauinput_t pEta = L1TauEmu::tauinput_t(fEta_.get()[i0]);
+    L1TauEmu::tauinput_t pPhi = L1TauEmu::tauinput_t(fPhi_.get()[i0]);
 
     NNvectorVar_.push_back(pPt);
     NNvectorVar_.push_back(pEta);
@@ -45,12 +44,12 @@ void TauNNIdHW::SetNNVectorVar() {
 // loaded into the same process (cms-sw/cmssw#49632).
 Tau_NN_Result TauNNIdHW::EvaluateNN() {
   constexpr unsigned kNInputs = 80;
-  tauinput_t model_input[kNInputs];
+  L1TauEmu::tauinput_t model_input[kNInputs];
   for (unsigned int i = 0; i < NNvectorVar_.size(); i++) {
-    model_input[i] = tauinput_t(NNvectorVar_[i]);
+    model_input[i] = L1TauEmu::tauinput_t(NNvectorVar_[i]);
   }
 
-  typedef std::pair<std::array<tauresult_t, 1>, std::array<tauresult_t, 1>> pairtype;
+  typedef std::pair<std::array<L1TauEmu::tauresult_t, 1>, std::array<L1TauEmu::tauresult_t, 1>> pairtype;
   pairtype modelResult;
   modelRef_->prepare_input(model_input);
   modelRef_->predict();

--- a/L1Trigger/Phase2L1ParticleFlow/test/testNNPuppiTauModel.cppunit.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/test/testNNPuppiTauModel.cppunit.cc
@@ -15,6 +15,7 @@ namespace {
   typedef ap_fixed<16, 10> tauinput_t;
   typedef ap_fixed<16, 6> tauresult_t;
   constexpr int kNInputs = 80;
+  constexpr char const* kModelName = "NNPuppiTauModel_v1";
 }  // namespace
 
 class test_NNPuppiTauModel : public CppUnit::TestFixture {
@@ -33,19 +34,19 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION(test_NNPuppiTauModel);
 
 void test_NNPuppiTauModel::doModelLoad() {
-  auto loader = hls4mlEmulator::ModelLoader("NNPuppiTauModel_v1");
+  auto loader = hls4mlEmulator::ModelLoader(kModelName);
   auto model = loader.load_model();
 }
 
 void test_NNPuppiTauModel::doMultiModelLoad() {
-  auto loader_a = hls4mlEmulator::ModelLoader("NNPuppiTauModel_v1");
-  auto loader_b = hls4mlEmulator::ModelLoader("NNPuppiTauModel_v1");
+  auto loader_a = hls4mlEmulator::ModelLoader(kModelName);
+  auto loader_b = hls4mlEmulator::ModelLoader(kModelName);
   auto model_a = loader_a.load_model();
   auto model_b = loader_b.load_model();
 }
 
 void test_NNPuppiTauModel::doPredictSanity() {
-  auto loader = hls4mlEmulator::ModelLoader("NNPuppiTauModel_v1");
+  auto loader = hls4mlEmulator::ModelLoader(kModelName);
   auto model = loader.load_model();
 
   // All-zero input: not physically representative, but exercises the full


### PR DESCRIPTION
Applies the same review-comment fixes made in #3 to the CMSSW_17_0_X backport branch used by [cms-sw/cmssw#51294](https://github.com/cms-sw/cmssw/pull/51294) (backport of #51263).

Addresses the review comments left on [cms-sw/cmssw#51263 review](https://github.com/cms-sw/cmssw/pull/51263#pullrequestreview-4639490333) by @quinnanm:

- `TauNNIdHW.h`: move the `tauinput_t`/`tauresult_t` typedefs into the `L1TauEmu` namespace to avoid clashing with other hls4ml model headers, updating all call sites accordingly.
- `TauNNIdHW.cc`: replace the empty `~TauNNIdHW() {}` definition with `~TauNNIdHW() = default;` in the header.
- `testNNPuppiTauModel.cppunit.cc`: store the repeated `"NNPuppiTauModel_v1"` string in a single `kModelName` constant.
- `L1NNTauProducer_cff.py`: store the repeated `"NNPuppiTauModel_v1"` string in a single `nnPuppiTauModelName` variable and reuse it for both producer configs.

Base is set to `nnpuppitau-externals-migration_CMSSW_17_0_X` so this can be merged into it directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fkn1Lb31fwkBSN4JVtom9h)_